### PR TITLE
Add CTO Insights (Podcast) to the Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ A curated and **opinionated** list of resources for [Chief Technology Officers a
  * [Rands Leadership Slack](https://randsinrepose.com/welcome-to-rands-leadership-slack/)
  * [Engineering Managers Slack](https://engmanagers.github.io)
  * [CTO Framework](https://ctoframework.com)
+ * [CTO Insights Podcast](https://ctoinsights.adevait.com/)
 
 
 ## Other


### PR DESCRIPTION
Added the CTO Insights podcast link to the Links section to make it easier for visitors to discover in-depth conversations with engineering leaders.